### PR TITLE
Enable message sending on Enter key and disable input conditionally

### DIFF
--- a/client/src/components/chat/InputField.vue
+++ b/client/src/components/chat/InputField.vue
@@ -31,6 +31,8 @@ const sendMessage = async () => {
         v-model="inputField"
         class="flex-1 px-2 sm:px-4 py-2 bg-slate-50 border border-slate-500 rounded-lg focus:outline-none focus:border-slate-600"
         placeholder="Введите сообщение..."
+        @keyup.enter="sendMessage"
+        :disabled="!ChatStore.activeChat || !ChatStore.activeChat.can_user_write"
     />
     <button
         @click="sendMessage"


### PR DESCRIPTION
Added an event listener to send messages on pressing Enter. Also disabled the input field when there's no active chat or the user lacks write permissions.